### PR TITLE
Add endpoint for membership requests

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -45,7 +45,8 @@ class Events
         /* @var \humhub\modules\rest\Module $restModule */
         $restModule = Yii::$app->getModule('rest');
         $restModule->addRules([
-            ['pattern' => 'auth/register/', 'route' => 'smartVillage/user/user/create', 'verb' => 'POST']
+            ['pattern' => 'auth/register/', 'route' => 'smartVillage/user/user/create', 'verb' => 'POST'],
+            ['pattern' => 'space/<spaceId:\d+>/membership/<userId:\d+>/request', 'route' => 'smartVillage/user/membership/request-for-membership', 'verb' => 'POST'],
         ], 'smartVillage');
     }
 }

--- a/components/AuthBaseController.php
+++ b/components/AuthBaseController.php
@@ -42,8 +42,7 @@ abstract class AuthBaseController extends Controller
      * @inheritdoc
      */
 
-    public function beforeAction($action)
-    {
+    public function beforeAction($action){
         Yii::$app->response->format = 'json';
 
         Yii::$app->request->setBodyParams(null);
@@ -59,8 +58,7 @@ abstract class AuthBaseController extends Controller
      * @param User $user
      * @return bool
      */
-    public function isUserEnabled(User $user)
-    {
+    public function isUserEnabled(User $user){
         $config = new ConfigureForm();
         $config->loadSettings();
 
@@ -83,8 +81,7 @@ abstract class AuthBaseController extends Controller
      * @param array $additional
      * @return array
      */
-    protected function returnError($statusCode = 400, $message = 'Invalid request', $additional = [])
-    {
+    protected function returnError($statusCode = 400, $message = 'Invalid request', $additional = []){
         Yii::$app->response->statusCode = $statusCode;
         return array_merge(['code' => $statusCode, 'message' => $message], $additional);
     }
@@ -98,8 +95,7 @@ abstract class AuthBaseController extends Controller
      * @param array $additional
      * @return array
      */
-    protected function returnSuccess($message = 'Request successful', $statusCode = 200, $additional = [])
-    {
+    protected function returnSuccess($message = 'Request successful', $statusCode = 200, $additional = []){
         Yii::$app->response->statusCode = $statusCode;
         return array_merge(['code' => $statusCode, 'message' => $message], $additional);
     }

--- a/controllers/user/GroupController.php
+++ b/controllers/user/GroupController.php
@@ -11,19 +11,18 @@ use Yii;
 class GroupController extends AuthBaseController
 {
     /**
-     *  By Default humhub default group is USER group whose id is 2,
+     *  By Default Humhub default group is USER group whose id is 2,
      */
     const USER_DEFAULT_GROUP_ID = 2;
 
     /**
-     * Adds the user to a particular humhub group by passing groupID and userID
+     * Adds the user to a particular Humhub group by passing groupID and userID
      *
      * @param $id
      * @param $userId
      * @return array
      */
-    public function actionMemberAddWithoutAuth($id,$userId)
-    {
+    public function actionMemberAddWithoutAuth($id,$userId){
         $group = Group::findOne(['id' => $id]);
         if ($group === null) {
             return $this->returnError(404, 'Group not found!');

--- a/controllers/user/MembershipController.php
+++ b/controllers/user/MembershipController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace humhub\modules\smartVillage\controllers\user;
+
+use humhub\modules\smartVillage\components\AuthBaseController;
+use humhub\modules\space\models\Membership;
+use humhub\modules\space\models\Space;
+use humhub\modules\user\models\User;
+use humhub\modules\space\notifications\ApprovalRequest;
+
+class MembershipController extends AuthBaseController
+{
+    /**
+     * group_id of space membership request will be 'member'
+     */
+    const USERGROUP_MEMBER = 'member';
+
+    /**
+     *  group_id of admin of a particular space will be 'admin'
+     */
+    const USERGROUP_ADMIN = 'admin';
+
+    /**
+     * Status of space membership request will be 2
+     */
+    const STATUS_APPLICANT = 2;
+
+    /**
+     * Request for space membership with API
+     *
+     * Steps
+     * 1. It will check both spaceId and userId is valid or not.
+     * 2. It will check the user is already member of that space or not
+     * 3. Finally, Request for space membership will be sent by calling addMembership function
+     *
+     * Note: Once the request for space membership will be sent then admin of that space will get a notification
+     *
+     * @param $spaceId
+     * @param $userId
+     * @return array|void
+     */
+    public function actionRequestForMembership($spaceId,$userId){
+
+         $space = Space::findOne(['id'=>$spaceId]);
+         $user = User::findOne(['id' => $userId]);
+
+         if(empty($space)){
+             return $this->returnError(400,"Space not found");
+         }
+         if(empty($user)){
+               return $this->returnError(400, "User not found");
+         }
+
+         //Check user is already member or not
+         $checkUserMember = Membership::findOne(['user_id' => $userId, 'space_id' => $spaceId]);
+         if(isset($checkUserMember) && !empty($checkUserMember)){
+             return $this->returnError(400,'User is already member');
+         }
+
+        return $this->addMembership($spaceId,$userId);
+     }
+
+    /**
+     * Store the data of space membership request
+     * Return the response after saving the data
+     *
+     * @param $spaceId
+     * @param $userId
+     * @return array|void
+     */
+     public function addMembership($spaceId,$userId){
+         // Add Membership
+         $membership = new Membership([
+             'space_id' => $spaceId,
+             'user_id' => $userId,
+             'status' => MembershipController::STATUS_APPLICANT,
+             'group_id' => MembershipController::USERGROUP_MEMBER
+             ]);
+
+         if($membership->save()){
+             $membership = Membership::findOne(['user_id' => $userId, 'space_id' => $spaceId]);
+             $user = User::findOne(['id' => $userId]);
+             $space = Space::findOne(['id'=>$spaceId]);
+
+             ApprovalRequest::instance()->from($user)->about($space)->sendBulk($this->getAdminsQuery($space));
+
+             return $this->returnSuccess("Success",200,[
+                'space_id' =>  $membership->space_id,
+                'user_id' => $membership->user_id,
+                'status' =>  $membership->status,
+                'group_id' => $membership->group_id
+             ]);
+         }else{
+             return $this->returnError(400,"Member not added!");
+         }
+     }
+
+    public function getAdminsQuery($space){
+        $query = Membership::getSpaceMembersQuery($space);
+        $query->andWhere(['space_membership.group_id' => MembershipController::USERGROUP_ADMIN]);
+
+        return $query;
+    }
+}

--- a/controllers/user/UserController.php
+++ b/controllers/user/UserController.php
@@ -26,8 +26,7 @@ class UserController extends AuthBaseController
      *
      * @return array
      */
-    public function actionCreate()
-    {
+    public function actionCreate(){
         $user = new User();
         $user->scenario = 'editAdmin';
         $user->load(Yii::$app->request->getBodyParam("account", []), '');

--- a/docs/postman/Smart Village API.postman_collection.json
+++ b/docs/postman/Smart Village API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e7f61874-18fc-44fc-a662-8958226e429b",
+		"_postman_id": "66517823-b452-408a-a2fc-2285d82f71c1",
 		"name": "Smart Village API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -37,6 +37,29 @@
 						"v1",
 						"auth",
 						"register"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Space membership request",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{API_URL}}/api/v1/space/1/membership/1/request",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"space",
+						"1",
+						"membership",
+						"1",
+						"request"
 					]
 				}
 			},


### PR DESCRIPTION
Now you can request for space membership through APIs.

Working Flows
  Steps
     1. First, It will check both spaceId and userId is valid or not.
      2. Second, It will check the user is already member of that space or not
      3. Finally, Request for space membership will be sent by calling addMembership function
     
Note: Once the request for space membership will be sent then admin of that space will get a notification

How to display notifications on admin's dashboard?
![image](https://user-images.githubusercontent.com/103625795/166440227-2c2f03d4-6935-4667-b4f4-d265c19db308.png)

1. When the request for membership sucessfully done, the notification data will sent to queue table.
2.  This 'queue' table is responsible to sent notifications to the admin of that space.
3.  for displaying the notifications,  you should type these commands in your terminal
       * First go to your Humhub's protected folder -> cd protected
       * Then type -> php yii queue/run 
       
#3 
