### PR TITLE
Add read/unread status of conversations

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -43,11 +43,11 @@ class Events
     public static function onRestApiAddRules()
     {
         /* @var \humhub\modules\rest\Module $restModule */
-        $restModule = Yii::$app->getModule('rest');
+        $restModule = Yii::$app->getModule('smartVillage');
         $restModule->addRules([
-            ['pattern' => 'auth/register/', 'route' => 'smartVillage/user/user/create', 'verb' => 'POST'],
+            ['pattern' => 'auth/register', 'route' => 'smartVillage/user/user/create', 'verb' => 'POST'],
             ['pattern' => 'space/<spaceId:\d+>/membership/<userId:\d+>/request', 'route' => 'smartVillage/user/membership/request-for-membership', 'verb' => 'POST'],
-            ['pattern' => 'mail/show-messages', 'route' => 'smartVillage/mail/message/index', 'verb' => 'GET'],
+            ['pattern' => 'mail', 'route' => 'smartVillage/mail/message/index', 'verb' => 'GET'],
         ], 'smartVillage');
     }
 }

--- a/Events.php
+++ b/Events.php
@@ -47,6 +47,7 @@ class Events
         $restModule->addRules([
             ['pattern' => 'auth/register/', 'route' => 'smartVillage/user/user/create', 'verb' => 'POST'],
             ['pattern' => 'space/<spaceId:\d+>/membership/<userId:\d+>/request', 'route' => 'smartVillage/user/membership/request-for-membership', 'verb' => 'POST'],
+            ['pattern' => 'mail/show-messages', 'route' => 'smartVillage/mail/message/index', 'verb' => 'GET'],
         ], 'smartVillage');
     }
 }

--- a/Module.php
+++ b/Module.php
@@ -10,6 +10,12 @@ class Module extends \humhub\components\Module
     /**
     * @inheritdoc
     */
+
+    /**
+     * @var string Prefix for REST API endpoint URLs
+     */
+    const API_URL_PREFIX = 'api/v2/';
+
     public function getConfigUrl()
     {
         return Url::to(['/smartVillage/admin']);
@@ -22,5 +28,40 @@ class Module extends \humhub\components\Module
     {
         // Cleanup all module data, don't remove the parent::disable()!!!
         parent::disable();
+    }
+
+    /**
+     * Add REST API endpoint rules
+     *
+     * @param array $rules
+     * @param string $moduleId Provide module id if you want to make if disabled from settings of the module "REST API"
+     */
+    public function addRules($rules, $moduleId = null)
+    {
+        if ($moduleId !== null && !$this->isActiveModule($moduleId)) {
+            return;
+        }
+
+        foreach ($rules as $r => $rule) {
+            if (isset($rule['pattern'])) {
+                $rules[$r]['pattern'] = self::API_URL_PREFIX . ltrim($rule['pattern'], '/');
+            }
+        }
+
+        Yii::$app->urlManager->addRules($rules);
+    }
+
+
+    /**
+     * Check if the module is active for additional REST API endpoints
+     *
+     * @param string $moduleId
+     * @return bool
+     */
+    public function isActiveModule($moduleId)
+    {
+        $apiModules = (array)$this->settings->getSerialized('apiModules');
+
+        return !isset($apiModules[$moduleId]) || $apiModules[$moduleId];
     }
 }

--- a/controllers/mail/MessageController.php
+++ b/controllers/mail/MessageController.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace humhub\modules\smartVillage\controllers\mail;
+
+use humhub\modules\rest\components\BaseController;
+use yii\db\Query;
+use Yii;
+use yii\data\Pagination;
+
+class MessageController extends BaseController
+{
+    /**
+     * Fetching conversation's data from both message and user_message of a user
+     * @return array
+     */
+     public function actionIndex(){
+         $results = [];
+
+         $messagesQuery = new Query();
+         $messagesQuery->select("*")->from('message')
+                        ->leftJoin('user_message', 'user_message.message_id = message.id')
+                        ->where(['user_id' => Yii::$app->user->id]);
+
+         foreach ($messagesQuery->all() as $message) {
+             $results[] = self::getMessage($message);
+         }
+         return $results;
+     }
+
+    /**
+     * Check the new unread message is found or not.
+     * Based on the $checkNewMessage array, it will set unread/read status of conversation
+     * When first time new unread message is found, the seen_at key will be null
+     *
+     * @param $message
+     * @return array
+     */
+      public static function getMessage($message){
+          $checkNewMessage = new Query();
+          $checkNewMessage->select("*")->from('message')
+              ->leftJoin('user_message', 'user_message.message_id = message.id')
+              ->where('message.updated_at > user_message.last_viewed OR user_message.last_viewed IS NULL')
+              ->andWhere(['<>','message.updated_by',Yii::$app->user->id])
+              ->andWhere(['user_message.user_id' => Yii::$app->user->id])
+              ->andWhere(['message.id' => $message['id']]);
+
+          $checkNewMessage = $checkNewMessage->count();
+          return [
+              'id' => $message['id'],
+              'title' => $message['title'],
+              'created_at' => $message['created_at'],
+              'created_by' => $message['created_by'],
+              'updated_at' => $message['updated_at'],
+              'updated_by' => $message['updated_by'],
+              'status' => $checkNewMessage>0?'unread':'read',
+              'seen_at' => $message['last_viewed'],
+          ];
+      }
+
+    /**
+     * Handles pagination
+     *
+     * @param Query $query
+     * @param int $limit
+     * @return Pagination the pagination
+     */
+      protected function handlePagination(Query $query, $limit = 100)
+    {
+        $limit = (int)Yii::$app->request->get('limit', $limit);
+        $page = (int)Yii::$app->request->get('page', 1);
+
+        if ($limit > 100) {
+            $limit = 100;
+        }
+
+        $page--;
+
+        $countQuery = clone $query;
+        $pagination = new Pagination(['totalCount' => $countQuery->count()]);
+        $pagination->setPage($page);
+        $pagination->setPageSize($limit);
+
+        $query->offset($pagination->offset);
+        $query->limit($pagination->limit);
+
+        return $pagination;
+    }
+
+      /**
+     * Generates pagination response
+     *
+     * @param Query $query
+     * @param Pagination $pagination
+     * @param $data array
+     * @return array
+     */
+      protected function returnPagination(Query $query, Pagination $pagination, $data)
+    {
+        return [
+            'total' => $pagination->totalCount,
+            'page' => $pagination->getPage() + 1,
+            'pages' => $pagination->getPageCount(),
+            'links' => $pagination->getLinks(),
+            'results' => $data,
+        ];
+    }
+}

--- a/docs/postman/Smart Village API.postman_collection.json
+++ b/docs/postman/Smart Village API.postman_collection.json
@@ -6,6 +6,58 @@
 	},
 	"item": [
 		{
+			"name": "List Conversations",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjF9.yZ8sgeZ1DcjplfixhuSa7ilO6_w6CkVtmTxAJcckfFMZ_68Z71oJYYaSHrgd7LWYPSS31DBK_X1ox-YpGUcy4A",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{API_URL}}/api/v2/mail",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"api",
+						"v2",
+						"mail"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Space membership request",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{API_URL}}/api/v2/space/1/membership/1/request",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"api",
+						"v2",
+						"space",
+						"1",
+						"membership",
+						"1",
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Add new user",
 			"request": {
 				"auth": {
@@ -28,68 +80,15 @@
 					}
 				},
 				"url": {
-					"raw": "{{API_URL}}/api/v1/auth/register",
+					"raw": "{{API_URL}}/api/v2/auth/register",
 					"host": [
 						"{{API_URL}}"
 					],
 					"path": [
 						"api",
-						"v1",
+						"v2",
 						"auth",
 						"register"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Space membership request",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"url": {
-					"raw": "{{API_URL}}/api/v1/space/1/membership/1/request",
-					"host": [
-						"{{API_URL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"space",
-						"1",
-						"membership",
-						"1",
-						"request"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "List Conversations",
-			"request": {
-				"auth": {
-					"type": "bearer",
-					"bearer": [
-						{
-							"key": "token",
-							"value": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjF9.yZ8sgeZ1DcjplfixhuSa7ilO6_w6CkVtmTxAJcckfFMZ_68Z71oJYYaSHrgd7LWYPSS31DBK_X1ox-YpGUcy4A",
-							"type": "string"
-						}
-					]
-				},
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{API_URL}}/api/v1/mail/show-messages",
-					"host": [
-						"{{API_URL}}"
-					],
-					"path": [
-						"api",
-						"v1",
-						"mail",
-						"show-messages"
 					]
 				}
 			},

--- a/docs/postman/Smart Village API.postman_collection.json
+++ b/docs/postman/Smart Village API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "66517823-b452-408a-a2fc-2285d82f71c1",
+		"_postman_id": "e9ec9439-e07f-4089-8ba3-331b5c727316",
 		"name": "Smart Village API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -60,6 +60,36 @@
 						"membership",
 						"1",
 						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "List Conversations",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOjF9.yZ8sgeZ1DcjplfixhuSa7ilO6_w6CkVtmTxAJcckfFMZ_68Z71oJYYaSHrgd7LWYPSS31DBK_X1ox-YpGUcy4A",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{API_URL}}/api/v1/mail/show-messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"api",
+						"v1",
+						"mail",
+						"show-messages"
 					]
 				}
 			},


### PR DESCRIPTION
* 'add status' key and 'seen_at' in result which show the conversation is read or unread

Working Flow:

When you hit the {{API_URL}}/api/v1/mail/show-messages Url. list of all conversations in which the user is participating will be shown.

* We are adding two more key in result
1. status: this key will show whether the conversation is read/unread.

2. seen_at : this key will show the time when user last time open that conversation.

#4 