### PR TITLE
Allow to read public contents without login through API

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -60,6 +60,10 @@ class Events
             ['pattern' => 'post', 'route' => 'smartVillage/post/post/find', 'verb' => 'GET'],
             ['pattern' => 'post/<Id:\d+>', 'route' => 'smartVillage/post/post/view', 'verb' => 'GET'],
             ['pattern' => 'post/container/<containerId:\d+>', 'route' => 'smartVillage/post/post/find-by-container', 'verb' => ['GET', 'HEAD']],
+
+            //space
+            ['pattern' => 'space', 'route' => 'smartVillage/space/space/index', 'verb' => 'GET'],
+            ['pattern' => 'space/<spaceId:\d+>', 'route' => 'smartVillage/space/space/view', 'verb' => 'GET'],
         ], 'smartVillage');
     }
 }

--- a/Events.php
+++ b/Events.php
@@ -55,6 +55,11 @@ class Events
             ['pattern' => 'calendar', 'route' => 'smartVillage/calendar/calendar/find', 'verb' => 'GET'],
             ['pattern' => 'calendar/entry/<Id:\d+>', 'route' => 'smartVillage/calendar/calendar/view', 'verb' => 'GET'],
             ['pattern' => 'calendar/container/<containerId:\d+>', 'route' => 'smartVillage/calendar/calendar/find-by-container', 'verb' => ['GET', 'HEAD']],
+
+            //post
+            ['pattern' => 'post', 'route' => 'smartVillage/post/post/find', 'verb' => 'GET'],
+            ['pattern' => 'post/<Id:\d+>', 'route' => 'smartVillage/post/post/view', 'verb' => 'GET'],
+            ['pattern' => 'post/container/<containerId:\d+>', 'route' => 'smartVillage/post/post/find-by-container', 'verb' => ['GET', 'HEAD']],
         ], 'smartVillage');
     }
 }

--- a/Events.php
+++ b/Events.php
@@ -50,6 +50,11 @@ class Events
             ['pattern' => 'mail', 'route' => 'smartVillage/mail/message/index', 'verb' => 'GET'],
             //mark unread message of conversation as read
             ['pattern' => 'mail/<messageId:\d+>/entries', 'route' => 'smartVillage/mail/entry/index', 'verb' => 'GET'],
+
+            //calendar
+            ['pattern' => 'calendar', 'route' => 'smartVillage/calendar/calendar/find', 'verb' => 'GET'],
+            ['pattern' => 'calendar/entry/<Id:\d+>', 'route' => 'smartVillage/calendar/calendar/view', 'verb' => 'GET'],
+            ['pattern' => 'calendar/container/<containerId:\d+>', 'route' => 'smartVillage/calendar/calendar/find-by-container', 'verb' => ['GET', 'HEAD']],
         ], 'smartVillage');
     }
 }

--- a/Events.php
+++ b/Events.php
@@ -62,7 +62,7 @@ class Events
             ['pattern' => 'post/container/<containerId:\d+>', 'route' => 'smartVillage/post/post/find-by-container', 'verb' => ['GET', 'HEAD']],
 
             //space
-            ['pattern' => 'space', 'route' => 'smartVillage/space/space/index', 'verb' => 'GET'],
+            ['pattern' => 'space', 'route' => 'smartVillage/space/space/find', 'verb' => 'GET'],
             ['pattern' => 'space/<spaceId:\d+>', 'route' => 'smartVillage/space/space/view', 'verb' => 'GET'],
         ], 'smartVillage');
     }

--- a/controllers/calendar/CalendarController.php
+++ b/controllers/calendar/CalendarController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace humhub\modules\smartVillage\controllers\calendar;
+
+use humhub\modules\calendar\helpers\RestDefinitions;
+use humhub\modules\content\components\ActiveQueryContent;
+use humhub\modules\content\components\ContentActiveRecord;
+use humhub\modules\content\models\ContentContainer;
+use humhub\modules\rest\definitions\ContentDefinitions;
+use humhub\modules\smartVillage\components\AuthBaseController;
+use humhub\modules\calendar\models\CalendarEntry;
+
+
+class CalendarController extends AuthBaseController
+{
+    /**
+     * @return mixed
+     * Get all the entries of calendar
+     */
+    public function actionFind(){
+        $query = CalendarEntry::find()->joinWith('content')->orderBy(['content.created_at' => SORT_DESC])->readable();
+
+        $pagination = $this->handlePagination($query);
+
+        $results = [];
+        foreach ($query->all() as $contentRecord) {
+            /** @var ContentActiveRecord $contentRecord */
+            $results[] = RestDefinitions::getCalendarEntry($contentRecord);
+        }
+
+        return $this->returnPagination($query, $pagination, $results);
+    }
+
+    /**
+     * Get calendar entry by passing id
+     * @param $Id
+     * @return array
+     */
+    public function actionView($Id){
+        $entry = CalendarEntry::findOne(['id'=>$Id]);
+
+        if(isset($entry) && !empty($entry)){
+            return RestDefinitions::getCalendarEntry($entry);
+
+        }else{
+            return $this->returnError(400, "Requested content not found!");
+        }
+    }
+
+    /**
+     * Finds content by given container
+     *
+     * @param integer $containerId the id of the content container
+     * @return array the rest output
+     * @throws \yii\db\IntegrityException
+     */
+    public function actionFindByContainer($containerId)
+    {
+        $contentContainer = ContentContainer::findOne(['id' => $containerId]);
+        if ($contentContainer === null) {
+            return $this->returnError(404, 'Content container not found!');
+        }
+
+        /** @var ActiveQueryContent $query */
+        $query = CalendarEntry::find()->contentContainer($contentContainer->getPolymorphicRelation())->orderBy(['content.created_at' => SORT_DESC])->readable();
+
+        ContentDefinitions::handleTopicsParam($query, $containerId);
+
+        $pagination = $this->handlePagination($query);
+
+        $results = [];
+
+        foreach ($query->all() as $contentRecord) {
+            /** @var ContentActiveRecord $contentRecord */
+            $results[] = RestDefinitions::getCalendarEntry($contentRecord);
+        }
+
+        return $this->returnPagination($query, $pagination, $results);
+    }
+
+}

--- a/controllers/post/PostController.php
+++ b/controllers/post/PostController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace humhub\modules\smartVillage\controllers\post;
+
+use humhub\modules\content\components\ActiveQueryContent;
+use humhub\modules\content\components\ContentActiveRecord;
+use humhub\modules\content\models\ContentContainer;
+use humhub\modules\post\models\Post;
+use humhub\modules\rest\definitions\ContentDefinitions;
+use humhub\modules\rest\definitions\PostDefinitions;
+use humhub\modules\smartVillage\components\AuthBaseController;
+
+class PostController extends AuthBaseController
+{
+    public function actionFind(){
+        $query = Post::find()->joinWith('content')->orderBy(['content.created_at' => SORT_DESC])->readable();
+
+        $pagination = $this->handlePagination($query);
+
+        $results = [];
+        foreach ($query->all() as $post) {
+            $results[] = PostDefinitions::getPost($post);
+
+        }
+
+        return $this->returnPagination($query, $pagination, $results);
+    }
+
+    public function actionView($Id){
+        $post = Post::findOne(['id'=>$Id]);
+
+        if(isset($post) && !empty($post)){
+            return PostDefinitions::getPost($post);
+
+        }else{
+            return $this->returnError(400, "Requested post not found!");
+        }
+    }
+
+    /**
+     * Finds content by given container
+     *
+     * @param integer $containerId the id of the content container
+     * @return array the rest output
+     * @throws \yii\db\IntegrityException
+     */
+    public function actionFindByContainer($containerId)
+    {
+        $contentContainer = ContentContainer::findOne(['id' => $containerId]);
+        if ($contentContainer === null) {
+            return $this->returnError(404, 'Content container not found!');
+        }
+
+        /** @var ActiveQueryContent $query */
+        $query = Post::find()->contentContainer($contentContainer->getPolymorphicRelation())->orderBy(['content.created_at' => SORT_DESC])->readable();
+
+        ContentDefinitions::handleTopicsParam($query, $containerId);
+
+        $pagination = $this->handlePagination($query);
+
+        $results = [];
+
+        foreach ($query->all() as $post) {
+            /** @var ContentActiveRecord $post */
+            $results[] = PostDefinitions::getPost($post);
+        }
+
+        return $this->returnPagination($query, $pagination, $results);
+    }
+}

--- a/controllers/space/SpaceController.php
+++ b/controllers/space/SpaceController.php
@@ -8,7 +8,7 @@ use humhub\modules\rest\definitions\SpaceDefinitions;
 
 class SpaceController extends AuthBaseController
 {
-    public function actionIndex(){
+    public function actionFind(){
         $results = [];
         $query = Space::find()->where(['visibility' => Space::VISIBILITY_ALL]);
 

--- a/controllers/space/SpaceController.php
+++ b/controllers/space/SpaceController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace humhub\modules\smartVillage\controllers\space;
+
+use humhub\modules\smartVillage\components\AuthBaseController;
+use humhub\modules\space\models\Space;
+use humhub\modules\rest\definitions\SpaceDefinitions;
+
+class SpaceController extends AuthBaseController
+{
+    public function actionIndex(){
+        $results = [];
+        $query = Space::find()->where(['visibility' => Space::VISIBILITY_ALL]);
+
+        $pagination = $this->handlePagination($query);
+        foreach ($query->all() as $space) {
+            $results[] = SpaceDefinitions::getSpace($space);
+        }
+        if(count($results) > 0){
+            return $this->returnPagination($query, $pagination, $results);
+        }else{
+            return $this->returnError(400,"No space data is publicly available!");
+        }
+    }
+
+    public function actionView($spaceId){
+        $checkSpace = Space::findOne($spaceId);
+        $checkVisibility = Space::find()->where(['id'=> $spaceId])->andWhere(['visibility' => Space::VISIBILITY_ALL])->one();
+
+        if(!isset($checkSpace)){
+            return $this->returnError(400,"Space not found!");
+        }
+
+        if(!isset($checkVisibility)){
+            return $this->returnError(400,"Guest user cannot read this space data");
+        }
+
+        $space = Space::find()->where(['id'=> $spaceId])->andWhere(['visibility' => Space::VISIBILITY_ALL])->one();
+
+        if(isset($space) && !empty($space)){
+            return SpaceDefinitions::getSpace($space);
+        }
+    }
+
+}

--- a/docs/postman/Smart Village API.postman_collection.json
+++ b/docs/postman/Smart Village API.postman_collection.json
@@ -6,6 +6,114 @@
 	},
 	"item": [
 		{
+			"name": "Calendar",
+			"item": [
+				{
+					"name": "Get all calendars entries",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"description": "admin",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_ADMIN}}",
+								"disabled": true
+							},
+							{
+								"description": "test",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_TEST}}"
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/api/v2/calendar",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"calendar"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get calendars entries by container",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"description": "admin",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_ADMIN}}",
+								"disabled": true
+							},
+							{
+								"description": "test",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_TEST}}"
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/api/v2/calendar/container/2",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"calendar",
+								"container",
+								"2"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get calendar entry by id",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"description": "admin",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_ADMIN}}"
+							},
+							{
+								"description": "test",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_TEST}}",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/api/v2/calendar/entry/2",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"calendar",
+								"entry",
+								"2"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "List Conversations",
 			"request": {
 				"auth": {

--- a/docs/postman/Smart Village API.postman_collection.json
+++ b/docs/postman/Smart Village API.postman_collection.json
@@ -114,6 +114,99 @@
 			]
 		},
 		{
+			"name": "Post",
+			"item": [
+				{
+					"name": "Get Posts by container id",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{API_URL}}/api/v2/post/container/2",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"post",
+								"container",
+								"2"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get all posts",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"description": "admin",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_ADMIN}}",
+								"disabled": true
+							},
+							{
+								"description": "test",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_TEST}}"
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/api/v2/post",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"post"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get post by id",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"description": "admin",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_ADMIN}}"
+							},
+							{
+								"description": "test",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_TEST}}",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/api/v2/post/2",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"post",
+								"2"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "List Conversations",
 			"request": {
 				"auth": {

--- a/docs/postman/Smart Village API.postman_collection.json
+++ b/docs/postman/Smart Village API.postman_collection.json
@@ -207,6 +207,78 @@
 			]
 		},
 		{
+			"name": "Space",
+			"item": [
+				{
+					"name": "Get all spaces",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"description": "admin",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_ADMIN}}",
+								"disabled": true
+							},
+							{
+								"description": "test",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_TEST}}"
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/api/v2/space",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"space"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get space by id",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"description": "admin",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_ADMIN}}"
+							},
+							{
+								"description": "test",
+								"key": "Authorization",
+								"type": "text",
+								"value": "{{AUTHORIZATION_TEST}}",
+								"disabled": true
+							}
+						],
+						"url": {
+							"raw": "{{API_URL}}/api/v2/space/2",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"space",
+								"2"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "List Conversations",
 			"request": {
 				"auth": {


### PR DESCRIPTION
User can read calendar, post and space data without login or bearer token.

Endpoints:
 **Calendar**
  /calendar = This endpoint fetch all the calendar's entries data.
 /calendar/entry/{id} = This endpoint fetch specific entry of calendar.
/calendar/container/{container-id} = This endpoint fetch all entries of calendar of specific container.

**Post**
 /post = This endpoint fetch all post data.
 /post/{id} = This endpoint fetch specific post data.
 /post/container/{container-id} = This endpoint fetch all posts of specific container.

**Space**
 /space = This endpoint fetch all space data.
 /space/{id} = This endpoint fetch specific space data.
Note : only those spaces data will be visible without login who's visibility set =2 .

#6 