### PR TITLE
Avoid legal module or set checkbox with registration #22

### DIFF
--- a/controllers/user/UserController.php
+++ b/controllers/user/UserController.php
@@ -39,9 +39,16 @@ class UserController extends AuthBaseController
             if(!$legalKey){
                 return $this->returnError(400,"Registration failed, legal module is activated but key is missing");
             }
-            //check the dataPrivacyCheck key is true or false
+
+            //Only allow 1, true, false and 0 value of dataPrivacyCheck key
+            $checkKeyValue = array(1,true,false,0);
+            if(!in_array($model->dataPrivacyCheck,$checkKeyValue,true)){
+                return $this->returnError(400,"Invalid value of dataPrivacyCheck key");
+            }
+
+            //check if the value of dataPrivacyCheck key is false
             if(!$model->dataPrivacyCheck){
-                return $this->returnError(400,"Registration failed,dataPrivacyCheck key is false");
+                return $this->returnError(400,"Registration failed, dataPrivacyCheck key is false");
             }
         }
         $user = new User();

--- a/controllers/user/UserController.php
+++ b/controllers/user/UserController.php
@@ -112,8 +112,12 @@ class UserController extends AuthBaseController
 
         $jwt = JWT::encode($data, $config->jwtKey, 'HS512');
 
-        //Accept the privacy policy page
-        $this->acceptPrivacy($user);
+        //Check the legal module is active or not
+        $module = Yii::$app->getModule('legal');
+        if($module !== null){
+            //Accept the privacy policy page
+            $this->acceptPrivacy($user);
+        }
 
         return $this->returnSuccess('Success', 200, [
             'auth_token' => $jwt,

--- a/docs/postman/Smart Village API.postman_collection.json
+++ b/docs/postman/Smart Village API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e9ec9439-e07f-4089-8ba3-331b5c727316",
+		"_postman_id": "a7d4eddd-ac59-4400-92b3-e8c8ad51ba97",
 		"name": "Smart Village API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -72,7 +72,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"account\": {\n    \"username\": \"kim.doe\",\n    \"email\": \"kim.doe@example.com\",\n    \"status\": 1,\n    \"tagsField\": [\n      \"Administration\",\n      \"Support\",\n      \"HumHub\"\n    ],\n    \"contentcontainer_id\": 5\n  },\n  \"profile\": {\n    \"firstname\": \"John\",\n    \"lastname\": \"Doe\",\n    \"title\": \"Test user\",\n    \"gender\": \"male\"\n\n  },\n  \"password\": {\n    \"newPassword\": \"SuperSecretPassword\", \n \"newPasswordConfirm\": \"SuperSecretPassword\" \n  }\n}",
+					"raw": "{\n  \"account\": {\n    \"username\": \"kim.doe\",\n    \"email\": \"kim.doe@example.com\",\n    \"status\": 1,\n    \"tagsField\": [\n      \"Administration\",\n      \"Support\",\n      \"HumHub\"\n    ],\n    \"contentcontainer_id\": 5\n  },\n  \"profile\": {\n    \"firstname\": \"John\",\n    \"lastname\": \"Doe\",\n    \"title\": \"Test user\",\n    \"gender\": \"male\"\n\n  },\n   \"legal\":{\n       \"dataPrivacyCheck\" : true\n  },\n  \"password\": {\n    \"newPassword\": \"SuperSecretPassword\", \n \"newPasswordConfirm\": \"SuperSecretPassword\" \n  }\n}",
 					"options": {
 						"raw": {
 							"language": "json"


### PR DESCRIPTION
 **Now, we can accept privacy policy during user registration**

Working Flow.

1. We set dataPrivacyCheck key in form-data (by default it is true), which means that privacy policy will be accepted during registration.

2. If we set false value of dataPrivacyCheck then, it will not accept privacy policy during registration.

3. We created a function(acceptPrivacy) in userController, which is responsible for accept the policy page.

4. This function will check the privacy policy setting will be enabled or not.

5. This function will also check the privacy policy page is exists or not and if not then it will show an error.

One suggestion: In future, we can also create an endpoint which accept privacy policy after registration.

#22 