### PR TITLE
Add endpoint to upload files to mails #59

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -53,6 +53,10 @@ class Events
 
             ['pattern' => 'space/<spaceId:\d+>/membership/<userId:\d+>/request', 'route' => 'smartVillage/user/membership/request-for-membership', 'verb' => 'POST'],
             ['pattern' => 'mail', 'route' => 'smartVillage/mail/message/index', 'verb' => 'GET'],
+
+            //Issue-59
+            ['pattern' => 'mail/<messageId:\d+>/upload-files', 'route' => 'smartVillage/mail/file-upload/index', 'verb' => 'POST'],
+
             //mark unread message of conversation as read
             ['pattern' => 'mail/<messageId:\d+>/entries', 'route' => 'smartVillage/mail/entry/index', 'verb' => 'GET'],
 

--- a/controllers/mail/FileUploadController.php
+++ b/controllers/mail/FileUploadController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace humhub\modules\smartVillage\controllers\mail;
+
+use humhub\modules\file\models\FileUpload;
+use humhub\modules\mail\models\Message;
+use humhub\modules\mail\models\MessageEntry;
+use humhub\modules\rest\components\BaseController;
+use humhub\modules\rest\definitions\FileDefinitions;
+use yii\web\UploadedFile;
+use Yii;
+
+class FileUploadController extends BaseController
+{
+    public function actionIndex($messageId){
+
+        $contentRecord = Message::findOne(['id' => $messageId]);
+
+        if ($contentRecord === null) {
+            return $this->returnError(404, 'Content record not found!');
+        }
+        $hideInStream = 1;
+        $uploadedFiles = UploadedFile::getInstancesByName('files');
+
+
+        if (empty($uploadedFiles)) {
+            return $this->returnError(400, 'No files to upload.');
+        }
+
+        $files = [];
+        foreach($uploadedFiles as $cFile){
+            $file = Yii::createObject(FileUpload::class);
+            $file->setUploadedFile($cFile);
+
+            if ($hideInStream) {
+                $file->show_in_stream = false;
+            }
+            if ($file->save()) {
+
+                $message = '!['.$file["file_name"].'](file-guid:'.$file["guid"].' "'.$file["file_name"].'")';
+                $messageEntry = new MessageEntry([
+                    'message_id' => $contentRecord->id,
+                    'user_id' => Yii::$app->user->id,
+                    'content' => $message
+                ]);
+                if($messageEntry->save()){
+                    $messageEntry->refresh();
+                    $messageEntry->notify();
+                    $messageEntry->fileManager->attach($file);
+                }
+
+            }
+            $files[] = $file;
+
+        }
+        if (empty($files)) {
+            return $this->returnError(500, 'Internal error while saving file.');
+        }
+
+        $fileDefinitions = [];
+        foreach ($files as $file) {
+            $fileDefinitions[] = FileDefinitions::getFile($file);
+        }
+
+        return $this->returnSuccess('Files successfully uploaded.', 200, ['files' => $fileDefinitions]);
+
+    }
+
+}

--- a/docs/postman/Smart Village API.postman_collection.json
+++ b/docs/postman/Smart Village API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "671f8086-1b87-423e-a0c3-9d1463466363",
+		"_postman_id": "88194e98-1c16-47e4-99bd-23f888387db5",
 		"name": "Smart Village API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "17408055"
@@ -778,6 +778,55 @@
 							"response": []
 						}
 					]
+				}
+			]
+		},
+		{
+			"name": "mail",
+			"item": [
+				{
+					"name": "Upload Files",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "files[]",
+									"type": "file",
+									"src": "/G:/INeuron/live class projects/Tailwind/projects/shopify/assets/screenshots/screenshot-1.png"
+								},
+								{
+									"key": "files[]",
+									"type": "file",
+									"src": "/G:/INeuron/live class projects/Tailwind/projects/rode/assets/images/rode-nth-2.jpg",
+									"disabled": true
+								}
+							]
+						},
+						"url": {
+							"raw": "{{API_URL}}/api/v2/mail/1/upload-files",
+							"host": [
+								"{{API_URL}}"
+							],
+							"path": [
+								"api",
+								"v2",
+								"mail",
+								"1",
+								"upload-files"
+							],
+							"query": [
+								{
+									"key": "file",
+									"value": null,
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},


### PR DESCRIPTION
Now, you can upload multiple files to mails via API.

Endpoint: /mail/<messageId/upload-files

messageId: Id of the conversation. Each conversation has is own unique Id.

Note: As of now, we are not checking the type of file user uploaded. So, the user can upload .sql,.exe, etc. files as well.

#59 