### PR TITLE
Add location value in calendar query #64

### DIFF
--- a/controllers/calendar/CalendarController.php
+++ b/controllers/calendar/CalendarController.php
@@ -3,7 +3,7 @@
 namespace humhub\modules\smartVillage\controllers\calendar;
 
 use Firebase\JWT\JWT;
-use humhub\modules\calendar\helpers\RestDefinitions;
+use humhub\modules\smartVillage\controllers\calendar\helpers\RestDefinitions;
 use humhub\modules\content\components\ActiveQueryContent;
 use humhub\modules\content\components\ContentActiveRecord;
 use humhub\modules\content\models\Content;

--- a/controllers/calendar/helpers/RestDefinitions.php
+++ b/controllers/calendar/helpers/RestDefinitions.php
@@ -23,7 +23,7 @@ class RestDefinitions
             'allow_decline' => (int)$entry->allow_decline,
             'allow_maybe' => (int)$entry->allow_maybe,
             'time_zone' => $entry->time_zone,
-            'location' => $entry->location ?? "",
+            'location' => $entry->location,
             'participant_info' => $entry->participant_info,
             'closed' => (int)$entry->closed,
             'max_participants' => (int)$entry->max_participants,

--- a/controllers/calendar/helpers/RestDefinitions.php
+++ b/controllers/calendar/helpers/RestDefinitions.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace humhub\modules\smartVillage\controllers\calendar\helpers;
+
+use humhub\modules\calendar\models\CalendarEntry;
+use humhub\modules\calendar\models\CalendarEntryParticipant;
+use humhub\modules\rest\definitions\ContentDefinitions;
+use humhub\modules\rest\definitions\UserDefinitions;
+
+class RestDefinitions
+{
+    public static function getCalendarEntry(CalendarEntry $entry)
+    {
+        return [
+            'id' => $entry->id,
+            'title' => $entry->title,
+            'description' => $entry->description,
+            'start_datetime' => $entry->start_datetime,
+            'end_datetime' => $entry->end_datetime,
+            'all_day' => (int)$entry->all_day,
+            'participation_mode' => (int)$entry->participation_mode,
+            'color' => $entry->color,
+            'allow_decline' => (int)$entry->allow_decline,
+            'allow_maybe' => (int)$entry->allow_maybe,
+            'time_zone' => $entry->time_zone,
+            'location' => $entry->location ?? "",
+            'participant_info' => $entry->participant_info,
+            'closed' => (int)$entry->closed,
+            'max_participants' => (int)$entry->max_participants,
+            'content' => ContentDefinitions::getContent($entry->content),
+            'participants' => static::getParticipantUsers($entry->getParticipantEntries()->with('user')->all())
+        ];
+    }
+
+    private static function getParticipantUsers($participants)
+    {
+        $result = [
+            'attending' => [],
+            'maybe' => [],
+            'declined' => []
+        ];
+
+        foreach ($participants as $participant) {
+            if ($participant->participation_state === CalendarEntryParticipant::PARTICIPATION_STATE_ACCEPTED) {
+                $result['attending'][] = UserDefinitions::getUserShort($participant->user);
+            } elseif ($participant->participation_state === CalendarEntryParticipant::PARTICIPATION_STATE_MAYBE){
+                $result['maybe'][] = UserDefinitions::getUserShort($participant->user);
+            } elseif ($participant->participation_state === CalendarEntryParticipant::PARTICIPATION_STATE_DECLINED){
+                $result['declined'][] = UserDefinitions::getUserShort($participant->user);
+            }
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Now, the user will get the location's data while fetching the calendar entries.

Note: In humhub core file, the 'location' key is not added to the output result. so, we created our new file 'RestDefinitions' in 'calendar' folder and returned all the data with the 'location' key.

#64 