### PR TITLE
Respect calendar entries over multiple days on start_date filter #67

### DIFF
--- a/controllers/calendar/CalendarController.php
+++ b/controllers/calendar/CalendarController.php
@@ -35,7 +35,7 @@ class CalendarController extends AuthBaseController
         if(isset($_GET['start_date']) || isset($_GET['end_date'])){
             if(isset($_GET['start_date']) && !isset($_GET['end_date'])) {
                 $start = $_GET['start_date'];
-                $query->andFilterWhere(['>=', 'start_datetime', $start]);
+                $query->andFilterWhere(['>=', 'start_datetime', $start])->orFilterWhere(['>=', 'end_datetime', $start]);
             }
             elseif (!isset($_GET['start_date']) && isset($_GET['end_date'])){
                 $end = $_GET['end_date'];
@@ -113,7 +113,7 @@ class CalendarController extends AuthBaseController
         if(isset($_GET['start_date']) || isset($_GET['end_date'])){
             if(isset($_GET['start_date']) && !isset($_GET['end_date'])) {
                 $start = $_GET['start_date'];
-                $query->andFilterWhere(['>=', 'start_datetime', $start]);
+                $query->andFilterWhere(['>=', 'start_datetime', $start])->orFilterWhere(['>=', 'end_datetime', $start]);
             }
             elseif (!isset($_GET['start_date']) && isset($_GET['end_date'])){
                 $end = $_GET['end_date'];


### PR DESCRIPTION
Now, you will get the event if it lies in start_date and end_date

For Example, if An event is created on 15th Sept. and ends on 22nd Sept. then if you will be fetching the event by passing start_date=2022-09-18 then the event will be getting because it lies in the date range.

#67 